### PR TITLE
🐛 Fix: Camera not opening when permission already granted

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -147,18 +147,30 @@ function App() {
     setUrl(`${event.target.value}?morphTargets=ARKit&textureAtlas=1024`);
   };
 
-  useEffect(() => {
-    setup();
+useEffect(() => {
+  setup();
 
-    // Listen for browser-level permission changes (Chrome, etc.)
-    // This allows us to detect if the user goes into settings and later grants camera access
-    if (navigator.permissions) {
-      navigator.permissions.query({ name: "camera" as PermissionName }).then((result) => {
+  if (navigator.permissions) {
+    navigator.permissions.query({ name: "camera" as PermissionName }).then((result) => {
+      setPermissionState(result.state as any);
+
+      // If camera is already allowed, open it immediately
+      if (result.state === "granted") {
+        requestCamera();
+      }
+
+      // Watch for changes (e.g. user updates permissions via browser settings)
+      result.onchange = () => {
         setPermissionState(result.state as any);
-        result.onchange = () => setPermissionState(result.state as any);
-      });
-    }
-  }, []);
+
+        if (result.state === "granted") {
+          requestCamera();
+        }
+      };
+    });
+  }
+}, []);
+
 
   return (
     <div className="App">


### PR DESCRIPTION
When users had already granted camera permissions in their browser, the app would not automatically start the camera.

This happened because getUserMedia() was only called when the user clicked the Allow Camera button inside the popup.

If navigator.permissions.query returned "granted" on load, the app skipped the permission popup but also never requested the camera stream.

What’s Fixed

Updated the useEffect logic:

If the permission state is already "granted", the app now calls requestCamera() immediately.

Also added logic inside the onchange event handler so that if permissions are later granted via browser settings, the camera stream opens automatically.

Why This Matters

Users who had previously allowed camera permissions saw a blank app with no video feed.

With this fix, the app seamlessly handles all cases:

First-time users → see popup → can allow.

Returning users (already granted) → camera starts automatically.

Users who denied then later allow in browser settings → app starts camera automatically.