### PR TITLE
fix: instant motion row with saving indicator, auto-select on upload …

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -144,7 +144,7 @@ function App() {
 
   // ── Subscribe to playback-ready events from useMotionRecorder ────────────
   useEffect(() => {
-    return subscribePlaybackReady(({ blob, motionId, name }) => {
+    return subscribePlaybackReady(({ blob, motionId, name, durationSeconds }) => {
       setPlaybackBlob(blob);
       setActiveMotionId(motionId);
       setActiveMotionName(name.replace(/\.glb$/i, ""));
@@ -156,18 +156,18 @@ function App() {
       // Always open the library when a motion is saved so the user sees it placed there
       setLibraryOpen(true);
 
-      // For guest users (not logged in), create a local pending motion so they can
-      // see and download the motion they just recorded
-      if (!hasDriveAccess()) {
-        const localMotion: DriveMotionFile = {
-          driveFileId: motionId,
-          name: name,
-          size: blob.size,
-          modifiedTime: new Date().toISOString(),
-          duration: undefined,
-        };
-        setPendingMotion(localMotion);
-      }
+      // Immediately create an optimistic pending motion for ALL users (guest and
+      // logged-in) so the row appears in the library without any delay.
+      // For logged-in users this row shows a "saving…" spinner until Drive
+      // confirms the upload; subscribeMotionUploaded will replace it.
+      const optimisticMotion: DriveMotionFile = {
+        driveFileId: motionId,
+        name: name,
+        size: blob.size,
+        modifiedTime: new Date().toISOString(),
+        duration: durationSeconds,
+      };
+      setPendingMotion(optimisticMotion);
 
       // If already signed in, the Drive upload fires inside stopRecording().
       // Set uploading status immediately and wait for the upload to resolve
@@ -192,14 +192,26 @@ function App() {
   // ── Subscribe to Drive upload completions ─────────────────────────────────
   // When uploadToDrive() succeeds (from any call site — stopRecording, the
   // hasDrive-transition effect, etc.) we get the DriveMotionFile back and:
-  //  1. Set it as pendingMotion → renders immediately at the top of the library
-  //  2. Bump libraryRefreshKey → triggers a silent background re-fetch so the
+  //  1. Replace pendingMotion with the confirmed Drive file (real driveFileId)
+  //  2. If the user is still on this motion (activeMotionId matches the optimistic
+  //     id), update activeMotionId to the real Drive file ID so selection stays correct
+  //  3. Bump libraryRefreshKey → triggers a silent background re-fetch so the
   //     list eventually reflects the canonical Drive order
-  //  3. Increment libraryMotionCount for the badge
-  //  4. Mark driveUploadStatus as "done"
+  //  4. Increment libraryMotionCount for the badge
+  //  5. Mark driveUploadStatus as "done"
   useEffect(() => {
     return subscribeMotionUploaded((file) => {
       setPendingMotion(file);
+      setActiveMotionId((currentId) => {
+        // If the user is still viewing the optimistic motion, point to the real one
+        // We can't compare directly since we don't have the optimistic ID here,
+        // but if the current ID starts with "motion_" it's the local optimistic one
+        if (currentId && currentId.startsWith("motion_")) {
+          setActiveMotionName(file.name.replace(/\.glb$/i, ""));
+          return file.driveFileId;
+        }
+        return currentId;
+      });
       setLibraryRefreshKey((k) => k + 1);
       setLibraryMotionCount((c) => c + 1);
       setDriveUploadStatus("done");
@@ -406,6 +418,7 @@ function App() {
           onLoginRequest={() => setShowAuthModal(true)}
           isInPlayback={isInPlayback}
           playbackBlob={playbackBlob}
+          isPendingUploading={driveUploadStatus === "uploading"}
         />
       )}
 

--- a/src/components/MotionLibrary.tsx
+++ b/src/components/MotionLibrary.tsx
@@ -56,6 +56,8 @@ export interface MotionLibraryProps {
   isInPlayback?: boolean;
   /** The playback blob for guest users (used to download guest recordings) */
   playbackBlob?: Blob | null;
+  /** Whether the pending motion is currently being uploaded to Drive */
+  isPendingUploading?: boolean;
 }
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
@@ -95,6 +97,7 @@ const MotionLibrary: React.FC<MotionLibraryProps> = ({
   onLoginRequest,
   isInPlayback = false,
   playbackBlob = null,
+  isPendingUploading = false,
 }) => {
   const [motions, setMotions] = useState<DriveMotionFile[]>([]);
   const [loading, setLoading] = useState(true);
@@ -366,6 +369,9 @@ const MotionLibrary: React.FC<MotionLibraryProps> = ({
               const isActive = file.driveFileId === activeMotionId;
               const isDownloading = downloadingId === file.driveFileId;
               const isDeleting = deletingId === file.driveFileId;
+              // Pending motion is still uploading to Drive
+              const isThisPending = pendingMotion?.driveFileId === file.driveFileId;
+              const isSaving = isThisPending && isPendingUploading;
 
               return (
                 <div
@@ -395,10 +401,19 @@ const MotionLibrary: React.FC<MotionLibraryProps> = ({
                       {file.name.replace(/\.glb$/i, "")}
                     </span>
                     <span className="ml-item-meta">
-                      {file.duration != null && (
-                        <>{formatDuration(file.duration)} &middot; </>
+                      {isSaving ? (
+                        <span className="ml-item-saving">
+                          <span className="rec-spinner rec-spinner-xs" aria-hidden="true" />
+                          saving...
+                        </span>
+                      ) : (
+                        <>
+                          {file.duration != null && (
+                            <>{formatDuration(file.duration)} &middot; </>
+                          )}
+                          {formatBytes(file.size)}
+                        </>
                       )}
-                      {formatBytes(file.size)}
                     </span>
                   </div>
 
@@ -408,7 +423,7 @@ const MotionLibrary: React.FC<MotionLibraryProps> = ({
                     <button
                       className="ml-action-btn"
                       onClick={(e) => handleDownload(e, file)}
-                      disabled={isDownloading || isDeleting}
+                      disabled={isDownloading || isDeleting || isSaving}
                       aria-label={`Download ${file.name}`}
                       title="Download .glb"
                     >
@@ -418,7 +433,7 @@ const MotionLibrary: React.FC<MotionLibraryProps> = ({
                     <button
                       className="ml-action-btn ml-action-btn-delete"
                       onClick={(e) => handleDeleteClick(e, file)}
-                      disabled={isDeleting || isDownloading}
+                      disabled={isDeleting || isDownloading || isSaving}
                       aria-label={`Delete ${file.name}`}
                       title="Delete"
                     >


### PR DESCRIPTION
…confirm

- pendingMotion now set immediately for ALL users (guest + logged-in) the moment playbackReady fires, so the row appears in the library without any delay
- logged-in users see a spinner + 'saving...' label on the pending row while the Drive upload is in progress (isPendingUploading prop)
- once Drive confirms the upload, activeMotionId is swapped from the optimistic local id to the real Drive file id so the selected state stays correct
- action buttons (download/delete) are disabled while saving to prevent races