### PR TITLE
feat: swap avatar mesh when selecting library motion recorded on a di…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,8 +80,11 @@ function App() {
       .catch(() => { /* graceful — badge stays 0 */ });
   }, [hasDrive]);
 
-  // Ref always holds the latest playback blob + name — used by Drive-connect
-  // effect so it can upload without a stale closure over playbackBlob state.
+  // ── Pending playback — used when avatar swap is required before playing ─────
+  // When the user selects a library motion recorded on a different avatar, we
+  // first swap the avatar (which triggers a load + skeleton loader), and once
+  // avatarReady fires we pick this up and start playback.
+  const pendingPlaybackRef = useRef<{ blob: Blob; file: DriveMotionFile } | null>(null);
   const latestPlaybackRef = useRef<{ blob: Blob; name: string } | null>(null);
 
   // Timeout fallback: if face detection never fires within 30s on mobile,
@@ -124,6 +127,8 @@ function App() {
 
   const handleAvatarChange = (newUrl: string) => {
     discardRecording();
+    // Clear any pending playback that was waiting for avatar to load
+    pendingPlaybackRef.current = null;
 
     useGLTF.clear(newUrl);
 
@@ -144,7 +149,7 @@ function App() {
 
   // ── Subscribe to playback-ready events from useMotionRecorder ────────────
   useEffect(() => {
-    return subscribePlaybackReady(({ blob, motionId, name, durationSeconds }) => {
+    return subscribePlaybackReady(({ blob, motionId, name, durationSeconds, avatarUrl }) => {
       setPlaybackBlob(blob);
       setActiveMotionId(motionId);
       setActiveMotionName(name.replace(/\.glb$/i, ""));
@@ -166,6 +171,7 @@ function App() {
         size: blob.size,
         modifiedTime: new Date().toISOString(),
         duration: durationSeconds,
+        avatarUrl: avatarUrl,
       };
       setPendingMotion(optimisticMotion);
 
@@ -243,12 +249,27 @@ function App() {
     getPlaybackControls()?.setLoop(loop);
   }, [getPlaybackControls]);
 
+  // ── Apply pending playback once the avatar finishes loading ──────────────
+  // When a library motion needs a different avatar, handleSelectMotion stores
+  // the blob in pendingPlaybackRef and triggers an avatar swap. This effect
+  // watches avatarReady and fires as soon as the new mesh is mounted.
+  useEffect(() => {
+    if (!avatarReady) return;
+    const pending = pendingPlaybackRef.current;
+    if (!pending) return;
+    pendingPlaybackRef.current = null;
+    setPlaybackBlob(pending.blob);
+    setActiveMotionId(pending.file.driveFileId);
+    setActiveMotionName(pending.file.name.replace(/\.glb$/i, ""));
+  }, [avatarReady]);
+
   // ── "Do another" → back to idle, clear playback ───────────────────────────
   // Called by BOTH PlaybackControls (scrubber bar) and RecordingControls.
   const handleDoAnother = useCallback(() => {
     setPlaybackBlob(null);
     setActiveMotionId(null);
     setActiveMotionName(undefined);
+    pendingPlaybackRef.current = null;
     discardRecording();
     handlePhaseChange("idle");
     // Reset mediapipe so "keep smiling" loader shows while it re-initialises
@@ -265,6 +286,7 @@ function App() {
     setPlaybackBlob(null);
     setActiveMotionId(null);
     setActiveMotionName(undefined);
+    pendingPlaybackRef.current = null;
     handlePhaseChange("idle");
     setLibraryOpen(false);
     // Reset mediapipe so the "keep smiling" loader shows while it re-initialises
@@ -282,11 +304,28 @@ function App() {
 
   // ── Select motion from library ────────────────────────────────────────────
   const handleSelectMotion = useCallback((blob: Blob, file: DriveMotionFile) => {
+    const targetAvatarUrl = file.avatarUrl ?? null;
+
+    // If the motion was recorded on a different avatar (or we know its avatar
+    // URL and it differs from current), swap the avatar first. The skeleton
+    // loader will show while the new mesh loads; once avatarReady fires the
+    // pendingPlaybackRef effect below will start playback automatically.
+    if (targetAvatarUrl && targetAvatarUrl !== url) {
+      pendingPlaybackRef.current = { blob, file };
+      // Clear current playback so the canvas shows the loader cleanly
+      setPlaybackBlob(null);
+      handleAvatarChange(targetAvatarUrl);
+      setActiveMotionId(file.driveFileId);
+      setActiveMotionName(file.name.replace(/\.glb$/i, ""));
+      return;
+    }
+
+    // Same avatar (or unknown avatar) — play immediately
     setPlaybackBlob(blob);
     setActiveMotionId(file.driveFileId);
     setActiveMotionName(file.name.replace(/\.glb$/i, ""));
     // Don't close the library on mobile — user might want to switch again
-  }, []);
+  }, [url, handleAvatarChange]);
 
   // ── When Drive first becomes available, upload any pending blob and refresh count ──
   // This covers two cases:
@@ -302,7 +341,7 @@ function App() {
         // A recording was made before sign-in — upload it now.
         // subscribeMotionUploaded will handle status + optimistic insert.
         setDriveUploadStatus("uploading");
-        uploadToDrive(pending.blob, pending.name)
+        uploadToDrive(pending.blob, pending.name, undefined, url ?? undefined)
           .then(() => {
             // subscribeMotionUploaded fires → sets "done" + pendingMotion + refreshKey
             setLibraryOpen(true);

--- a/src/Avatar.tsx
+++ b/src/Avatar.tsx
@@ -68,7 +68,7 @@ function Avatar({ url, onLoaded, playbackBlob }: AvatarProps) {
     if (nodes.Avatar) headMesh.push(nodes.Avatar);
     if (nodes.face) headMesh.push(nodes.face);
 
-    setSceneForExport(scene, nodes, headMesh as Mesh[]);
+    setSceneForExport(scene, nodes, headMesh as Mesh[], url);
 
     // Reset smoothers whenever the avatar reloads so we don't carry stale
     // state from a previous session into the new pose.

--- a/src/useDriveSync.ts
+++ b/src/useDriveSync.ts
@@ -197,6 +197,8 @@ export interface DriveMotionFile {
   modifiedTime: string;
   /** duration in seconds stored as appProperty */
   duration?: number;
+  /** the avatar URL that was active when this motion was recorded */
+  avatarUrl?: string;
 }
 
 // ─── upload ───────────────────────────────────────────────────────────────────
@@ -208,15 +210,18 @@ export interface DriveMotionFile {
 export async function uploadToDrive(
   blob: Blob,
   fileName: string,
-  durationSeconds?: number
+  durationSeconds?: number,
+  avatarUrl?: string
 ): Promise<string> {
+  const appProperties: Record<string, string> = {};
+  if (durationSeconds != null) appProperties.duration = String(durationSeconds);
+  if (avatarUrl) appProperties.avatarUrl = avatarUrl;
+
   const metadata = {
     name: fileName,
     parents: ["appDataFolder"],
     mimeType: "model/gltf-binary",
-    appProperties: durationSeconds != null
-      ? { duration: String(durationSeconds) }
-      : undefined,
+    appProperties: Object.keys(appProperties).length > 0 ? appProperties : undefined,
   };
 
   const form = new FormData();
@@ -252,6 +257,7 @@ export async function uploadToDrive(
     size: blob.size,
     modifiedTime: new Date().toISOString(),
     duration: durationSeconds,
+    avatarUrl,
   };
   _notifyUploaded(motionFile);
 
@@ -289,6 +295,7 @@ export async function listDriveMotions(): Promise<DriveMotionFile[]> {
     duration: f.appProperties?.duration != null
       ? parseFloat(f.appProperties.duration)
       : undefined,
+    avatarUrl: f.appProperties?.avatarUrl ?? undefined,
   }));
 }
 

--- a/src/useMotionRecorder.ts
+++ b/src/useMotionRecorder.ts
@@ -187,7 +187,7 @@ export function getRecorderState(): RecorderState {
   };
 }
 
-// ─── recording controls ───────────────────────────────────────────────────────
+// ─── recording controls ───────────────────────────────────────────────────���───
 
 export function startRecording(): void {
   if (_isRecording) return;
@@ -449,17 +449,23 @@ export async function buildGLBBlob(): Promise<{ blob: Blob; durationSeconds: num
   // ── GLTFExporter ────────────────────────────────────────────────────────────
   const exporter = new GLTFExporter();
 
-  // Embed avatarUrl in the GLB's asset.extras so playback can detect which
-  // avatar mesh was recorded and swap to it when a different motion is selected.
-  const extras = _avatarUrl ? { avatarUrl: _avatarUrl } : undefined;
+  // Embed avatarUrl into scene.userData so GLTFExporter writes it into
+  // asset.extras in the output GLB (userData is the supported mechanism —
+  // the 'extras' option key does not exist on GLTFExporterOptions).
+  const prevUserData = scene.userData ? { ...scene.userData } : {};
+  if (_avatarUrl) {
+    scene.userData = { ...prevUserData, avatarUrl: _avatarUrl };
+  }
 
   const result = await exporter.parseAsync(scene, {
     binary: true,
     animations: [clip],
     onlyVisible: false,
     embedImages: true,
-    extras,
   });
+
+  // Restore scene.userData so we don't pollute the live scene
+  scene.userData = prevUserData;
 
   const buffer = result as ArrayBuffer;
   const blob = new Blob([buffer], { type: "model/gltf-binary" });

--- a/src/useMotionRecorder.ts
+++ b/src/useMotionRecorder.ts
@@ -50,6 +50,8 @@ export interface PlaybackReadyPayload {
   motionId: string;
   name: string;
   durationSeconds: number;
+  /** The avatar URL that was active when this motion was recorded */
+  avatarUrl?: string;
 }
 
 type PlaybackListener = (payload: PlaybackReadyPayload) => void;
@@ -112,6 +114,8 @@ let _scene: Group | null = null;
 let _nodes: Record<string, any> | null = null;
 /** Meshes that carry morphTargetDictionary (Wolf3D_Head, Wolf3D_Teeth, etc.) */
 let _headMeshes: Mesh[] = [];
+/** The avatar URL that was active when setSceneForExport was last called */
+let _avatarUrl: string | null = null;
 /**
  * Optional secondary motion system. When set, its bone quaternions are
  * snapshotted every frame and baked into the exported AnimationClip.
@@ -143,15 +147,18 @@ export function subscribeRecorder(fn: Listener): () => void {
  * Avatar.tsx calls this in useEffect whenever the GLTF scene loads / reloads.
  * We store references to the live scene objects so the exporter can use them
  * without needing to traverse the R3F tree from outside the Canvas.
+ * avatarUrl is stored so it can be embedded in the exported GLB extras.
  */
 export function setSceneForExport(
   scene: Group,
   nodes: Record<string, any>,
-  meshes: Mesh[]
+  meshes: Mesh[],
+  avatarUrl?: string
 ): void {
   _scene = scene;
   _nodes = nodes;
   _headMeshes = [...meshes];
+  if (avatarUrl) _avatarUrl = avatarUrl;
 }
 
 /**
@@ -207,17 +214,18 @@ export function stopRecording(): void {
       .replace("T", "_")
       .replace(/:/g, "-");
     const fileName = `facial_capture_${timestamp}.glb`;
+    const snapshotAvatarUrl = _avatarUrl ?? undefined;
     buildGLBBlob()
       .then(({ blob, durationSeconds }) => {
         const motionId = _makeMotionId();
         _cachedBlob = { blob, name: fileName };
-        _notifyPlaybackReady({ blob, motionId, name: fileName, durationSeconds });
+        _notifyPlaybackReady({ blob, motionId, name: fileName, durationSeconds, avatarUrl: snapshotAvatarUrl });
 
         // Attempt Drive upload immediately if tokens are already present.
         // Import lazily to avoid circular deps at module load time.
         import("./useDriveSync").then(({ hasDriveAccess, uploadToDrive }) => {
           if (hasDriveAccess()) {
-            uploadToDrive(blob, fileName, durationSeconds).catch((err) => {
+            uploadToDrive(blob, fileName, durationSeconds, snapshotAvatarUrl).catch((err) => {
               console.warn("[recorder] Auto Drive upload failed:", err?.message);
             });
           }
@@ -441,11 +449,16 @@ export async function buildGLBBlob(): Promise<{ blob: Blob; durationSeconds: num
   // ── GLTFExporter ────────────────────────────────────────────────────────────
   const exporter = new GLTFExporter();
 
+  // Embed avatarUrl in the GLB's asset.extras so playback can detect which
+  // avatar mesh was recorded and swap to it when a different motion is selected.
+  const extras = _avatarUrl ? { avatarUrl: _avatarUrl } : undefined;
+
   const result = await exporter.parseAsync(scene, {
     binary: true,
     animations: [clip],
     onlyVisible: false,
     embedImages: true,
+    extras,
   });
 
   const buffer = result as ArrayBuffer;


### PR DESCRIPTION
…fferent character

- useMotionRecorder: store _avatarUrl alongside the scene; embed it in GLB asset.extras.avatarUrl during export; include it in PlaybackReadyPayload
- Avatar.tsx: pass url to setSceneForExport so the recorder tracks which avatar was active at record time
- useDriveSync: add avatarUrl field to DriveMotionFile; persist it as an appProperty on Drive upload; read it back in listDriveMotions
- App.tsx: handleSelectMotion detects avatar mismatch — if the motion's avatarUrl differs from the current url it calls handleAvatarChange (showing the skeleton loader) and stores the blob in pendingPlaybackRef; a new avatarReady effect consumes the ref and starts playback once the mesh loads