### PR TITLE
preserve guest recording blob on login and handle missing Drive scope…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ import AvatarCanvas from "./AvatarCanvas";
 import { discardRecording, subscribePlaybackReady } from "./useMotionRecorder";
 import AuthButton from "./components/AuthButton";
 import AuthModal from "./components/AuthModal";
-import { hasDriveAccess, listDriveMotions, uploadToDrive, subscribeMotionUploaded, subscribeQuotaExceeded, DriveQuotaError, BulkSyncProgress } from "./useDriveSync";
+import { hasDriveAccess, listDriveMotions, uploadToDrive, subscribeMotionUploaded, subscribeQuotaExceeded, subscribeNoDriveScope, DriveQuotaError, BulkSyncProgress } from "./useDriveSync";
 import type { DriveMotionFile } from "./useDriveSync";
 
 function App() {
@@ -208,6 +208,18 @@ function App() {
     return subscribeQuotaExceeded(() => {
       setDriveUploadStatus("quota");
       setLibraryOpen(true); // open the library so the banner is visible
+    });
+  }, []);
+
+  // ── Subscribe to sign-in without Drive scope ──────────────────────────────
+  // When the user signs in with Google but does NOT grant Drive appdata access,
+  // supabaseClient fires notifyNoDriveScope(). We auto-open the AuthModal so
+  // they immediately see the friendly "grant Drive access" prompt. Their
+  // pending recording blob is still in latestPlaybackRef and will upload once
+  // they successfully grant access and hasDrive becomes true.
+  useEffect(() => {
+    return subscribeNoDriveScope(() => {
+      setShowAuthModal(true);
     });
   }, []);
 
@@ -485,6 +497,7 @@ function App() {
           quotaReached={driveUploadStatus === "quota"}
           isLoggedIn={hasDrive}
           onLoginRequest={() => setShowAuthModal(true)}
+          onNoDriveAccessRetry={() => setShowAuthModal(true)}
           isInPlayback={isInPlayback}
           playbackBlob={playbackBlob}
           isPendingUploading={driveUploadStatus === "uploading"}
@@ -499,6 +512,7 @@ function App() {
             setShowAuthModal(false);
             setHasDrive(hasDriveAccess());
           }}
+          hasPendingMotion={latestPlaybackRef.current !== null}
         />
       )}
     </div>

--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -13,9 +13,14 @@ interface AuthModalProps {
   onClose: () => void;
   /** Called after Drive scope is successfully obtained */
   onDriveConnected?: () => void;
+  /**
+   * When true the modal shows a stronger "you have an unsaved recording"
+   * message to encourage the user to grant Drive access.
+   */
+  hasPendingMotion?: boolean;
 }
 
-export default function AuthModal({ onClose, onDriveConnected }: AuthModalProps) {
+export default function AuthModal({ onClose, onDriveConnected, hasPendingMotion = false }: AuthModalProps) {
   const [loading, setLoading] = useState(false);
   const [user, setUser] = useState<User | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -103,9 +108,27 @@ export default function AuthModal({ onClose, onDriveConnected }: AuthModalProps)
           </p>
         ) : (
           <>
-            <p className="subtitle prompt-subtitle mt-8" style={{ fontSize: "13px" }}>
-              Connect Google Drive to save and sync your motions across devices.
-            </p>
+            {/* ── Drive scope missing ── */}
+            <div
+              className="ml-no-drive-banner"
+              role="alert"
+              style={{
+                marginTop: "12px",
+                padding: "12px 14px",
+                borderRadius: "10px",
+                background: "var(--bg-secondary, rgba(255,255,255,0.06))",
+                border: "1px solid var(--border-color, rgba(255,255,255,0.12))",
+              }}
+            >
+              <p style={{ margin: 0, fontSize: "13px", lineHeight: 1.5, color: "var(--text-primary)" }}>
+                <strong>Google Drive access was not granted.</strong>
+              </p>
+              <p style={{ margin: "6px 0 0", fontSize: "13px", lineHeight: 1.5, color: "var(--text-secondary)" }}>
+                {hasPendingMotion
+                  ? "Your recorded motion is still here and will be saved automatically once you grant access. Click below and make sure to check the Google Drive checkbox when Google asks."
+                  : "To save and sync your motions, you need to allow access to Google Drive. Click below and make sure to check the Google Drive checkbox when Google asks."}
+              </p>
+            </div>
             <button
               className="button primary w-full mt-8"
               onClick={handleGoogleLoginWithDrive}
@@ -119,7 +142,7 @@ export default function AuthModal({ onClose, onDriveConnected }: AuthModalProps)
               ) : (
                 <>
                   <span className="has-icon icon-size-16 google-icon" />
-                  connect Google Drive
+                  grant Google Drive access
                 </>
               )}
             </button>

--- a/src/components/MotionLibrary.tsx
+++ b/src/components/MotionLibrary.tsx
@@ -52,6 +52,11 @@ export interface MotionLibraryProps {
   isLoggedIn?: boolean;
   /** Called when the guest-state login button is clicked */
   onLoginRequest?: () => void;
+  /**
+   * Called when the user clicks the retry CTA after signing in without
+   * granting Drive access. Reopens the auth flow so they can grant it.
+   */
+  onNoDriveAccessRetry?: () => void;
   /** Whether currently in playback mode */
   isInPlayback?: boolean;
   /** The playback blob for guest users (used to download guest recordings) */
@@ -95,6 +100,7 @@ const MotionLibrary: React.FC<MotionLibraryProps> = ({
   quotaReached = false,
   isLoggedIn = false,
   onLoginRequest,
+  onNoDriveAccessRetry,
   isInPlayback = false,
   playbackBlob = null,
   isPendingUploading = false,
@@ -102,6 +108,7 @@ const MotionLibrary: React.FC<MotionLibraryProps> = ({
   const [motions, setMotions] = useState<DriveMotionFile[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [noDriveAccess, setNoDriveAccess] = useState(false);
   const [downloadingId, setDownloadingId] = useState<string | null>(null);
   const [downloadError, setDownloadError] = useState<string | null>(null);
   const [lastSynced, setLastSynced] = useState<Date | null>(null);
@@ -114,9 +121,11 @@ const MotionLibrary: React.FC<MotionLibraryProps> = ({
   // Load Drive motions
   const fetchMotions = useCallback(async (silent = false) => {
     if (!hasDriveAccess()) {
+      setNoDriveAccess(true);
       setLoading(false);
       return;
     }
+    setNoDriveAccess(false);
     if (!silent) setLoading(true);
     setLoadError(null);
     try {
@@ -295,6 +304,39 @@ const MotionLibrary: React.FC<MotionLibraryProps> = ({
             >
               <span className="has-icon icon-size-12 refresh-icon" aria-hidden="true" />
             </button>
+          </div>
+        )}
+
+        {/* ── No Drive access banner (signed in but Drive scope missing) ── */}
+        {isLoggedIn && noDriveAccess && (
+          <div
+            className="ml-no-drive-banner"
+            role="alert"
+            style={{
+              margin: "12px 0",
+              padding: "14px 16px",
+              borderRadius: "10px",
+              background: "var(--bg-secondary, rgba(255,255,255,0.06))",
+              border: "1px solid var(--border-color, rgba(255,255,255,0.12))",
+            }}
+          >
+            <p style={{ margin: 0, fontSize: "13px", fontWeight: 600, color: "var(--text-primary)" }}>
+              Google Drive access is needed
+            </p>
+            <p style={{ margin: "6px 0 10px", fontSize: "13px", lineHeight: 1.5, color: "var(--text-secondary)" }}>
+              It looks like Google Drive permission was not granted during sign-in. Your recorded motion is safe — click below to grant access and it will upload automatically.
+            </p>
+            {onNoDriveAccessRetry && (
+              <button
+                className="rec-btn rec-btn-record outline-5 outline-soft gap-2"
+                style={{ fontSize: "13px" }}
+                onClick={onNoDriveAccessRetry}
+                aria-label="Grant Google Drive access"
+              >
+                <span className="has-icon icon-size-14 google-icon" aria-hidden="true" />
+                grant Drive access
+              </button>
+            )}
           </div>
         )}
 

--- a/src/supabaseClient.ts
+++ b/src/supabaseClient.ts
@@ -4,7 +4,7 @@
  */
 
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
-import { storeDriveTokens, clearDriveTokens } from "./useDriveSync";
+import { storeDriveTokens, clearDriveTokens, notifyNoDriveScope } from "./useDriveSync";
 
 // ── Environment detection ────────────────────────────────────────────────────
 // On facemocap.radframes.com → use REACT_APP_SUPABASE_URL / ANON_KEY (prod vars).
@@ -60,6 +60,11 @@ if (supabase) {
         session.provider_refresh_token ?? null,
         session.user?.email
       );
+    }
+    if (event === "SIGNED_IN" && !session?.provider_token) {
+      // User signed in with Google but did not grant the Drive scope.
+      // Notify subscribers so the app can prompt them to retry with Drive access.
+      notifyNoDriveScope();
     }
     if (event === "SIGNED_OUT") {
       clearDriveTokens();

--- a/src/useDriveSync.ts
+++ b/src/useDriveSync.ts
@@ -43,6 +43,24 @@ function _notifyUploaded(file: DriveMotionFile) {
   _uploadListeners.forEach((fn) => fn(file));
 }
 
+// ─── no-Drive-scope notification ─────────────────────────────────────────────
+// Fired by supabaseClient.ts when a SIGNED_IN event arrives but provider_token
+// is absent — meaning the user authenticated with Google but did NOT grant the
+// Drive appdata scope. App.tsx listens to re-open AuthModal so the user can
+// retry without losing their pending recording blob.
+
+type NoDriveScopeListener = () => void;
+const _noDriveScopeListeners = new Set<NoDriveScopeListener>();
+
+export function subscribeNoDriveScope(fn: NoDriveScopeListener): () => void {
+  _noDriveScopeListeners.add(fn);
+  return () => _noDriveScopeListeners.delete(fn);
+}
+
+export function notifyNoDriveScope(): void {
+  _noDriveScopeListeners.forEach((fn) => fn());
+}
+
 // ─── quota notification ───────────────────────────────────────────────────────
 // Fired when any uploadToDrive() call fails with DriveQuotaError so App.tsx
 // can update driveUploadStatus="quota" regardless of which call site triggered it.


### PR DESCRIPTION
… gracefully

- useDriveSync: add subscribeNoDriveScope/notifyNoDriveScope pub/sub so the app can react when a user signs in without granting Drive appdata access
- supabaseClient: call notifyNoDriveScope() when SIGNED_IN fires without provider_token (user skipped Drive permission checkbox)
- AuthModal: accept hasPendingMotion prop; when user is signed in but Drive scope is missing, show a friendly explanation banner (mentions unsaved recording when applicable) and a 'grant Google Drive access' retry CTA instead of a silent 'connect Drive' button
- MotionLibrary: add onNoDriveAccessRetry prop; fetchMotions sets noDriveAccess state when hasDriveAccess() returns false; renders a Drive-access banner with a retry CTA instead of surfacing a raw error string
- App.tsx: subscribe to subscribeNoDriveScope — auto-opens AuthModal so the user is immediately guided to retry; passes hasPendingMotion and onNoDriveAccessRetry to AuthModal and MotionLibrary respectively; the latestPlaybackRef blob is preserved throughout so it uploads automatically once Drive access is successfully granted