### PR TITLE
Update site domain to vtuber.miniface.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   
   **Real-time face tracking with 3D avatars in your browser** ✨
 
-  Try it at : https://www.miniface.org/
+  Try it at : https://www.vtuber.miniface.org/
   
  [![License: MIT-Attribution](https://img.shields.io/badge/License-MIT--Attribution-yellow.svg)](LICENSE.md)
  [![React](https://img.shields.io/badge/React-18.2.0-blue.svg)](https://reactjs.org/)

--- a/public/index.html
+++ b/public/index.html
@@ -11,11 +11,11 @@
     <!-- Primary SEO -->
     <title>miniface - Real-time Facial Motion Capture & Animation</title>
     <meta name="description" content="miniface is an AI-powered real-time facial motion capture app for live face tracking and character animation, running entirely in your browser on web, iOS, and Android." />
-    <meta name="keywords" content="miniface, miniface.org, facial motion capture, face animation, live face animation, facial tracking AI, realtime animation, AI character animation, computer vision face tracking, mocap software" />
+    <meta name="keywords" content="miniface, vtuber.miniface.org, facial motion capture, face animation, live face animation, facial tracking AI, realtime animation, AI character animation, computer vision face tracking, mocap software" />
     <meta name="author" content="Pooya Moradi M." />
 
     <!-- Canonical URL -->
-    <link rel="canonical" href="https://www.miniface.org/" />
+    <link rel="canonical" href="https://www.vtuber.miniface.org/" />
 
     <!-- Preconnect to Google Fonts origins to resolve DNS/TLS early -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -33,16 +33,16 @@
     <meta property="og:title" content="miniface - Real-time Facial Motion Capture" />
     <meta property="og:description" content="miniface lets you track your face in realtime and create facial animations with AI-powered motion capture — entirely in your browser." />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://www.miniface.org/" />
-    <meta property="og:image" content="https://www.miniface.org/images/seo/og-image.jpg" />
+    <meta property="og:url" content="https://www.vtuber.miniface.org/" />
+    <meta property="og:image" content="https://www.vtuber.miniface.org/images/seo/og-image.jpg" />
     <meta property="og:site_name" content="miniface" />
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@minifaceorg" />
     <meta name="twitter:title" content="miniface - Real-time Facial Motion Capture" />
-    <meta name="twitter:description" content="Create live character animation with AI-powered realtime facial motion capture at miniface.org." />
-    <meta name="twitter:image" content="https://www.miniface.org/images/seo/twitter-image.jpg" />
+    <meta name="twitter:description" content="Create live character animation with AI-powered realtime facial motion capture at vtuber.miniface.org." />
+    <meta name="twitter:image" content="https://www.vtuber.miniface.org/images/seo/twitter-image.jpg" />
   <!-- Google tag (gtag.js) -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-YTRBDF94V3"></script>
 <script>
@@ -61,12 +61,12 @@
       "operatingSystem": "Web, iOS, Android",
       "applicationCategory": "MultimediaApplication",
       "description": "miniface is an AI-powered real-time facial motion capture app for live face tracking and character animation, running entirely in your browser.",
-      "url": "https://www.miniface.org/",
-      "image": "https://www.miniface.org/images/seo/app-preview.jpg",
+      "url": "https://www.vtuber.miniface.org/",
+      "image": "https://www.vtuber.miniface.org/images/seo/app-preview.jpg",
       "author": {
         "@type": "Person",
         "name": "Pooya Moradi M.",
-        "url": "https://www.miniface.org/"
+        "url": "https://www.vtuber.miniface.org/"
       },
       "offers": {
         "@type": "Offer",
@@ -79,7 +79,7 @@
 
     <!-- Optional: Fallback meta description if JS disabled -->
     <noscript>
-      <meta name="description" content="miniface helps you track faces in real-time using AI-powered technology for live character animation at miniface.org." />
+      <meta name="description" content="miniface helps you track faces in real-time using AI-powered technology for live character animation at vtuber.miniface.org." />
     </noscript>
   </head>
   <body>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://www.miniface.org/sitemap.xml
+Sitemap: https://www.vtuber.miniface.org/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://www.miniface.org/</loc>
+    <loc>https://www.vtuber.miniface.org/</loc>
     <lastmod>2026-06-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://www.miniface.org/privacy</loc>
+    <loc>https://www.vtuber.miniface.org/privacy</loc>
     <lastmod>2026-06-19</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
-    <loc>https://www.miniface.org/cookies</loc>
+    <loc>https://www.vtuber.miniface.org/cookies</loc>
     <lastmod>2026-06-19</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
-    <loc>https://www.miniface.org/terms</loc>
+    <loc>https://www.vtuber.miniface.org/terms</loc>
     <lastmod>2026-06-19</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -504,7 +504,7 @@ function App() {
     // Recordings may have been made with:
     //   (a) old local paths    – "/avatar/avatar3.glb"
     //   (b) Cloudinary URLs    – "https://res.cloudinary.com/da1zca4wj/.../avatar-braids.glb"
-    //   (c) preview-domain URLs – "https://preview.miniface.org/avatar/avatar3.glb"  (401s)
+    //   (c) preview-domain URLs – "https://preview.vtuber.miniface.org/avatar/avatar3.glb"  (401s)
     //
     // Strategy: extract the filename from whatever was stored and look it up in
     // the current AVATAR_METADATA registry. If a match is found, use that

--- a/src/pages/CookiesPage.tsx
+++ b/src/pages/CookiesPage.tsx
@@ -1,13 +1,13 @@
 /*
  * Copyright (c) 2025 Pooya Moradi M. arkitface@gmail.com
- * miniface.org
+ * vtuber.miniface.org
  */
 
 import "../App.css";
 import "./legal.css";
 
 const EFFECTIVE_DATE = "June 13, 2026";
-const DOMAIN = "miniface.org";
+const DOMAIN = "vtuber.miniface.org";
 const OWNER_NAME = "Pooya Moradi M.";
 const OWNER_CITY = "Rome, Italy";
 const CONTACT_EMAIL = "arkitface@gmail.com";

--- a/src/pages/PrivacyPage.tsx
+++ b/src/pages/PrivacyPage.tsx
@@ -1,13 +1,13 @@
 /*
  * Copyright (c) 2025 Pooya Moradi M. arkitface@gmail.com
- * miniface.org
+ * vtuber.miniface.org
  */
 
 import "../App.css";
 import "./legal.css";
 
 const EFFECTIVE_DATE = "June 13, 2026";
-const DOMAIN = "miniface.org";
+const DOMAIN = "vtuber.miniface.org";
 const OWNER_NAME = "Pooya Moradi M.";
 const OWNER_CITY = "Rome, Italy";
 const CONTACT_EMAIL = "arkitface@gmail.com";

--- a/src/pages/TermsPage.tsx
+++ b/src/pages/TermsPage.tsx
@@ -1,13 +1,13 @@
 /*
  * Copyright (c) 2025 Pooya Moradi M. arkitface@gmail.com
- * miniface.org
+ * vtuber.miniface.org
  */
 
 import "../App.css";
 import "./legal.css";
 
 const EFFECTIVE_DATE = "June 15, 2026";
-const DOMAIN = "miniface.org";
+const DOMAIN = "vtuber.miniface.org";
 const OWNER_NAME = "Pooya Moradi M.";
 const OWNER_CITY = "Rome, Italy";
 const CONTACT_EMAIL = "arkitface@gmail.com";

--- a/src/pages/legal.css
+++ b/src/pages/legal.css
@@ -1,6 +1,6 @@
 /*
  * Legal pages — Cookie Policy & Privacy Policy
- * miniface.org
+ * vtuber.miniface.org
  */
 
 /* =============================================

--- a/src/supabaseClient.ts
+++ b/src/supabaseClient.ts
@@ -7,14 +7,14 @@ import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { storeDriveTokens, clearDriveTokens, notifyNoDriveScope } from "./useDriveSync";
 
 // ── Environment detection ────────────────────────────────────────────────────
-// On miniface.org / www.miniface.org → use REACT_APP_SUPABASE_URL / ANON_KEY (prod vars).
+// On vtuber.miniface.org / www.vtuber.miniface.org → use REACT_APP_SUPABASE_URL / ANON_KEY (prod vars).
 // On every other host                → use REACT_APP_SUPABASE_STAGE_URL / STAGE_ANON_KEY.
 // Set the matching pair in Vercel's Environment Variables for each deployment.
 
 const isProductionHost =
   typeof window !== "undefined" &&
-  (window.location.hostname === "miniface.org" ||
-    window.location.hostname === "www.miniface.org");
+  (window.location.hostname === "vtuber.miniface.org" ||
+    window.location.hostname === "www.vtuber.miniface.org");
 
 const supabaseUrl = isProductionHost
   ? process.env.REACT_APP_SUPABASE_URL

--- a/src/useMotionRecorder.ts
+++ b/src/useMotionRecorder.ts
@@ -320,7 +320,7 @@ export function stopRecording(): void {
       .slice(0, 19)
       .replace("T", "_")
       .replace(/:/g, "-");
-    const fileName = `miniface.org_${timestamp}.glb`;
+    const fileName = `vtuber.miniface.org_${timestamp}.glb`;
     const snapshotAvatarUrl = _avatarUrl ?? undefined;
     buildGLBBlob()
       .then(({ blob, durationSeconds }) => {

--- a/vercel.json
+++ b/vercel.json
@@ -13,7 +13,7 @@
           "value": "facemocap.vercel.app"
         }
       ],
-      "destination": "https://www.miniface.org/$1",
+      "destination": "https://www.vtuber.miniface.org/$1",
       "permanent": true
     },
     {
@@ -24,7 +24,7 @@
           "value": "facemocap.radframes.app"
         }
       ],
-      "destination": "https://www.miniface.org/$1",
+      "destination": "https://www.vtuber.miniface.org/$1",
       "permanent": true
     },
     {
@@ -35,7 +35,7 @@
           "value": "facemocap.radframes.com"
         }
       ],
-      "destination": "https://www.miniface.org/$1",
+      "destination": "https://www.vtuber.miniface.org/$1",
       "permanent": true
     },
     {
@@ -43,10 +43,10 @@
       "has": [
         {
           "type": "host",
-          "value": "miniface.org"
+          "value": "vtuber.miniface.org"
         }
       ],
-      "destination": "https://www.miniface.org/$1",
+      "destination": "https://www.vtuber.miniface.org/$1",
       "permanent": true
     }
   ]


### PR DESCRIPTION
- Updated all internal links and configuration files to point to the new `vtuber.miniface.org` domain.
- Refactored URL structures across the codebase to support the new domain mapping.

[v0 Session](https://v0.app/miniface/chat/luMgndqNcFe)